### PR TITLE
Redesign memory access functions

### DIFF
--- a/dbg.proto
+++ b/dbg.proto
@@ -22,9 +22,9 @@ message Request {
 
 	required Type   type    = 1; //
 	optional string msg     = 2; // DEBUG_PRINT
-	optional int32  address = 3; // FREE, MEM_READ, MEM_WRITE
-	optional int32  size    = 4; // MALLOC, MEM_READ, MEM_WRITE
-	optional int64  value   = 5; // MEM_WRITE
+	optional uint32 address = 3; // FREE, MEM_READ, MEM_WRITE
+	optional uint32 size    = 4; // MALLOC, MEM_READ
+	optional bytes  data    = 5; // MEM_WRITE
 }
 
 message Response {
@@ -37,7 +37,7 @@ message Response {
 	required Type    type    = 1; //
 	optional string  msg     = 2; //
 	optional SysInfo info    = 3; // SYSINFO
-	optional int32   address = 4; // MALLOC
-	optional int32   size    = 5; // 
-	optional int64   value   = 6; // MEM_READ
+	optional uint32  address = 4; // MALLOC
+	optional uint32  size    = 5; //
+	optional bytes   data    = 6; // MEM_READ
 }

--- a/dbg.py
+++ b/dbg.py
@@ -58,17 +58,19 @@ class Xbox(object):
 		req.address = addr
 		return self._send_simple_request(req)
 
-	def mem(self, addr, value=None):
+	def mem(self, addr, size=0, data=None):
 		"""Read/write system memory"""
-		write = value is not None
+		write = data is not None
 		req = Request()
-		req.type    = Request.MEM_WRITE if write else Request.MEM_READ
-		req.address = addr
-		req.size    = 1 # TODO: Support word, dword, qword accesses
 		if write:
-			req.value = value
+			req.type = Request.MEM_WRITE
+			req.data = data
+		else:
+			req.type = Request.MEM_READ
+			req.size = size
+		req.address = addr
 		res = self._send_simple_request(req)
-		return res if write else res.value
+		return res if write else res.data
 
 	def debug_print(self, string):
 		"""Print a debug string to the screen"""

--- a/dbg.py
+++ b/dbg.py
@@ -58,19 +58,21 @@ class Xbox(object):
 		req.address = addr
 		return self._send_simple_request(req)
 
-	def mem(self, addr, size=0, data=None):
-		"""Read/write system memory"""
-		write = data is not None
+	def mem_read(self, addr, size):
+		"""read memory"""
 		req = Request()
-		if write:
-			req.type = Request.MEM_WRITE
-			req.data = data
-		else:
-			req.type = Request.MEM_READ
-			req.size = size
+		req.type = Request.MEM_READ
+		req.size = size
 		req.address = addr
-		res = self._send_simple_request(req)
-		return res if write else res.data
+		return self._send_simple_request(req).data
+
+	def mem_write(self, addr, data):
+		"""write memory"""
+		req = Request()
+		req.type = Request.MEM_WRITE
+		req.data = data
+		req.address = addr
+		return self._send_simple_request(req)
 
 	def debug_print(self, string):
 		"""Print a debug string to the screen"""
@@ -111,8 +113,8 @@ def main():
 	addr = xbox.malloc(1024)
 	val = 0x5A
 	print("Allocated memory at 0x%x" % addr)
-	xbox.mem(addr, val)
-	assert(xbox.mem(addr) == val)
+	xbox.mem_write(addr, bytes([val]))
+	assert(xbox.mem_read(addr, 1) == val)
 	xbox.free(addr)
 	
 	#xbox.reboot()


### PR DESCRIPTION
This redesigns the memory read / write functionality.
By giving it a deterministic data read/write behaviour it becomes useful for MMIO.

**The code was written more than a year ago, and I haven't tried re-compiling it recently.**

**I'll test this code again soon, but I'm already opening the PR so other people can test and review it.**

---

The proposed behaviour of the reads / writes is:

- You can write any size you want
- While there is more than 4 bytes left: read/write 4 bytes
- While there is more than 2 bytes left: read/write 2 bytes
- While there is more than 1 bytes left: read/write 1 byte

Logically, it's not possible to get more than one 2 byte write and one 1 byte write.
The `while` loops were still kept to make the repeating pattern in the code more obvious + someone might want to disable the 4 byte write or extend the function in the future.

I did consider design alternatives, but this setup works for most cases. Most MMIO registers are 4 byte on Xbox, so we can write a bunch of them at once (using a single packet / more or less atomic operation) if need-be. We can also read and write large blocks of data at okish-speeds, still.

**Known problem**

The protobuf `bytes` type probably doesn't free the allocated data anywhere. Therefore, this probably leaks memory.
An issue should be created after merge, so someone should look into this in the future.

---

The second commit is a design decision: Instead of using the existing `xbox.mem` function, this turns it into `xbox.mem_read` and `xbox.mem_write`.
This reflects the actual protobuf function names and avoids possible conflicts (where size and data can both be supplied for example).

I did consider naming the new functions just `read` and `write` to be more like the Python stream (file/socket) operations. However, we might want `xbox.io_write` and `xbox.io_read` later, so I decided to keep the protobuf names with the `mem_` prefix.