### PR TITLE
Add new CALL method

### DIFF
--- a/dbg.proto
+++ b/dbg.proto
@@ -16,15 +16,16 @@ message Request {
 		DEBUG_PRINT       = 6;
 		SHOW_DEBUG_SCREEN = 7;
 		SHOW_FRONT_SCREEN = 8;
+		CALL              = 9;
 
-		COUNT = 9;
+		COUNT = 10;
 	}
 
 	required Type   type    = 1; //
 	optional string msg     = 2; // DEBUG_PRINT
-	optional uint32 address = 3; // FREE, MEM_READ, MEM_WRITE
+	optional uint32 address = 3; // FREE, MEM_READ, MEM_WRITE, CALL
 	optional uint32 size    = 4; // MALLOC, MEM_READ
-	optional bytes  data    = 5; // MEM_WRITE
+	optional bytes  data    = 5; // MEM_WRITE, CALL
 }
 
 message Response {
@@ -39,5 +40,5 @@ message Response {
 	optional SysInfo info    = 3; // SYSINFO
 	optional uint32  address = 4; // MALLOC
 	optional uint32  size    = 5; //
-	optional bytes   data    = 6; // MEM_READ
+	optional bytes   data    = 6; // MEM_READ, CALL
 }


### PR DESCRIPTION
This implements a way of doing calls using the CPU on the remote.

Closes #6 

---

The following API / design has been chosen (click each to unfold if you care about reasons):

<details><summary>Stack data can be supplied which will run the virtual CPU, additionally, the virtual stack has 4096 more bytes, which should be enough for most tasks.</summary><br>

If that stack is not enough, the called function can set its own stack, because the real stack is always restored automatically on exit.
</details>

<details><summary>`pusha` and `popa` protect real register values. Float or special registers are not restored.</summary><br>

Also not done by XBDM interface of xboxpy, and hard to draw the line. For performance reasons, CPU registers are enough.
</details>

<details><summary>No registers are controlled on entry (except EIP and ESP).</summary><br>

The original code for this had a feature where the CALL controlled *every* register on entry. However Xbox mostly uses stdcall or cdecl, and passing all registers was slower and not beneficial in those cases.

If anyone needs registers on entry, they can inject their own CALL handler which pops register values from the virtual stack. Each connection would probably allocate their own helper and might not `free` it correctly either; problem?
</details>

<details><summary>The return value is currently a bytes object containing the memory layout of a `pusha`.</summary><br>

Done to keep the documentation simple. Not a big fan of this design, because transfers lots of memory, even for simple functions. Most functions / conventions only care about EAX and EDX, so I'm open to discussing changes. I felt transferring only EAX and EDX felt kind of arbitrary. Also did not want to add .eax and .edx just for the CALL (but I'm open to doing that).
</details>

---

I still recommend that people keep their code abstract though. CALL is a complex operation and design changes in the future might be necessary.

The provided sample injects `rdtsc; ret` and calls it repeatedly to measure time.
An older, more simple version of the code is shown, but it hardly shows off RDTSC as only one measurement was made.
I have only tested the sample with Python 3 yet. Python 2 test results would be appreciated.

I have also tested this with get_av_settings.py, a simple [python-script](https://github.com/JayFoxRox/xbox-tools/tree/master/python-scripts) (Requires https://github.com/XboxDev/xboxpy/pull/21).

I kept my development commits unsquashed, because I feel there'll be debate about how the sample should be written (I consider it to be too complicated in the last form) and how the API should work.

I'll also test more of my scripts during review to test behaviour.