### PR TITLE
Fix building on modern NXDK

### DIFF
--- a/dbgd.c
+++ b/dbgd.c
@@ -18,7 +18,6 @@
 #include <stdlib.h>
 #include <xboxkrnl/xboxkrnl.h>
 #include <xboxrt/debug.h>
-#include <xboxrt/string.h>
 
 #include "dbg.pb-c.h"
 #include "net.h"

--- a/net.c
+++ b/net.c
@@ -17,7 +17,6 @@
 #include <stdlib.h>
 #include <xboxkrnl/xboxkrnl.h>
 #include <xboxrt/debug.h>
-#include <xboxrt/string.h>
 
 #include "net.h"
 


### PR DESCRIPTION
Why this PR? 
In the current state of nxdk-rdt is it not able to build anymore due to renamed includes (which are unused) which is why this PR removes them.

This has been tested on Windows 10 with WSL Ubuntu.