### PR TITLE
Explicitly set video-mode at startup

### DIFF
--- a/main.c
+++ b/main.c
@@ -16,6 +16,8 @@
 /* Main program function */
 void main(void)
 {
+    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
+
     gfx_init();
     pb_print("NXDK Development Dash\n");
 


### PR DESCRIPTION
Preparing for https://github.com/XboxDev/nxdk-pdclib/pull/3

I did not test this change. It only moves the call to a later point / different thread, so it should be fine.