### PR TITLE
Small cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ clean: clean_local
 	protoc --python_out=$(CURDIR)/ $(notdir $<)
 
 %.pb-c.c %.pb-c.h: %.proto
-	protoc-c --c_out=$(CURDIR)/ $(notdir $<)
+	protoc --c_out=$(CURDIR)/ $(notdir $<)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SRCS += $(CURDIR)/dbg.pb-c.c # Might not exist when the wildcard above runs
 CFLAGS += -I$(CURDIR)
 CFLAGS += -I$(CURDIR)/lib
 
-all_local: all dbg_pb2.py
+all_local: dbg_pb2.py dbg.pb-c.c all
 
 include $(NXDK_DIR)/Makefile
 

--- a/dbgd.c
+++ b/dbgd.c
@@ -17,7 +17,7 @@
 #include <protobuf-c/protobuf-c.h>
 #include <stdlib.h>
 #include <xboxkrnl/xboxkrnl.h>
-#include <xboxrt/debug.h>
+#include <hal/debug.h>
 
 #include "dbg.pb-c.h"
 #include "net.h"

--- a/gfx.c
+++ b/gfx.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <strings.h>
 #include <xboxkrnl/xboxkrnl.h>
-#include <xboxrt/debug.h>
+#include <hal/debug.h>
 
 static float m_viewport[4][4];
 

--- a/main.c
+++ b/main.c
@@ -7,7 +7,7 @@
 #include <string.h>
 #include <strings.h>
 #include <xboxkrnl/xboxkrnl.h>
-#include <xboxrt/debug.h>
+#include <hal/debug.h>
 
 #include "net.h"
 #include "gfx.h"

--- a/net.c
+++ b/net.c
@@ -16,7 +16,7 @@
 #include <protobuf-c/protobuf-c.h>
 #include <stdlib.h>
 #include <xboxkrnl/xboxkrnl.h>
-#include <xboxrt/debug.h>
+#include <hal/debug.h>
 
 #include "net.h"
 


### PR DESCRIPTION
Ran into some hiccups while trying to build this project locally. Just up-streaming them:
- Latest NXDK moved `debug.h` to `hal`
- [Direct use of `protoc-c` is considered legacy now.](https://github.com/protobuf-c/protobuf-c/blob/master/protoc-c/main.cc#L12) This usage mode is also broken on `msys2` thanks to the `"/"` string comparison against `argv[0]`. protobuf-c is still required, but calling `protoc` with `--c_out` works when `protobuf-c` is available and is the preferred method now.
- I'm no `make` expert so this may be wrong, but default make rules did not compile either of the `python` or `c` protobufs which breaks the build. Re-ordered the build steps to fix this.